### PR TITLE
Attempt to fix compilation with MSVC conformance mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     string(REGEX REPLACE "/W[0-4]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
   endif()
 
   enable_testing()

--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -583,7 +583,7 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
           }
 
           if (op == opcode::op_destroy) {
-            to_table->template set_empty();
+            to_table->set_empty();
           }
           return;
         }

--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -545,7 +545,7 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
             from->ptr_ = nullptr;
 #endif
 
-            to_table->set_allocated<T>();
+            to_table->template set_allocated<T>();
 
           }
           // The object is allocated inplace
@@ -583,7 +583,7 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
           }
 
           if (op == opcode::op_destroy) {
-            to_table->set_empty();
+            to_table->template set_empty();
           }
           return;
         }
@@ -606,11 +606,11 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
       // Try to allocate the object inplace
       void* storage = retrieve<T>(std::true_type{}, to, to_capacity);
       if (storage) {
-        to_table->set_inplace<T>();
+        to_table->template set_inplace<T>();
       } else {
         // Allocate the object through the allocator
         to->ptr_ = storage = box.box_allocate();
-        to_table->set_allocated<T>();
+        to_table->template set_allocated<T>();
       }
       new (storage) T(std::forward<Box>(box));
     }


### PR DESCRIPTION
MSVC provides the `/permissive-` switch to enable maximal conformance with the C++ standard, disabling some non-standard code which might have passed otherwise.

With `/permissive-` enabled, the following does not compile under 
- Visual Studio 2017 Version 15.6.0 Preview 4.0; nor
- Visual Studio 2017 Version 15.5.6.

```
#include <function2/function2.hpp>

int main()
{
	return 0;
}
```

With the changes made to `function2.hpp` in this PR, the snippet above compiles successfully.

With the changes made to `CMakeLists.txt`, and the change above, the `function2_playground` target builds successfully as well. The `function2_test` target does not build on my machine at the moment, but this could be an issue with my GTest installation; I do not use GTest personally or at work and have not looked into it too much.