### PR TITLE
Conformance fix

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -4,8 +4,8 @@
 //       (See accompanying file LICENSE_1_0.txt or copy at
 //             http://www.boost.org/LICENSE_1_0.txt)
 
-#ifndef FU2_INCLUDED_FUNCTION2_HPP__
-#define FU2_INCLUDED_FUNCTION2_HPP__
+#ifndef FU2_INCLUDED_FUNCTION2_HPP_
+#define FU2_INCLUDED_FUNCTION2_HPP_
 
 #include <cassert>
 #include <cstdlib>


### PR DESCRIPTION
@Naios The code was not conforming to the standard limitations on reserved identifiers.

This commit makes it conforming to [[lex.name]/3.1](http://www.eel.is/c++draft/lex.name#3.1).

Since the change is _very obvious_ (but sadly, the problem was not captured by the tools), tests are omitted.

