### PR TITLE
Fix a typo in comment

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -94,7 +94,7 @@ struct copyable<false> {
 /// Configuration trait to configure the function_base class.
 template <bool Owning, bool Copyable, std::size_t Capacity>
 struct config {
-  // Is true if the function is copyable.
+  // Is true if the function is owning.
   static constexpr auto const is_owning = Owning;
 
   // Is true if the function is copyable.


### PR DESCRIPTION
Change "copyable" to "owning" for "is_owning".

@Naios 

This modification has no effect except for the comment.
