### PR TITLE
Disable empty propagation if compiling as Objective-C++ to allow succ…

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -58,6 +58,14 @@
 #endif
 #endif // FU2_WITH_CXX17_NOEXCEPT_FUNCTION_TYPE
 
+// Force disable empty propagation if compiled as Objective-C++
+// as lambdas get converted to a block pointer with an implicit copy,
+// causing non-copyable lambdas to not compile.
+// See https://stackoverflow.com/questions/59292997 for more details.
+#ifdef __OBJC__
+#define FU2_WITH_NO_EMPTY_PROPAGATION
+#endif
+
 // - FU2_HAS_NO_EMPTY_PROPAGATION
 #if defined(FU2_WITH_NO_EMPTY_PROPAGATION)
 #define FU2_HAS_NO_EMPTY_PROPAGATION


### PR DESCRIPTION
…essful compilation of non-copyable callables

@Naios <!-- This is required so I get notified properly -->

<!-- Please replace {Please write here} with your description -->

-----

### What was a problem?

Non-copyable lambdas failed to compile in Objective-C++.

### How this PR fixes the problem?

This PR disables the bool() operator optimisation if the class is being compiled as Objective-C++.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [x] Coding style (Clang format was applied)

### Additional Comments (if any)
 
Not sure how to add a unit test since it would require compiling as Objective-C++.
