### PR TITLE
fix: __has_builtin macro check

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -74,10 +74,13 @@
 #elif defined(__GNUC__)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define FU2_DETAIL_UNREACHABLE_INTRINSIC() __builtin_unreachable()
-#elif defined(__has_builtin) && __has_builtin(__builtin_unreachable)
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_unreachable)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define FU2_DETAIL_UNREACHABLE_INTRINSIC() __builtin_unreachable()
-#else
+#endif
+#endif
+#ifndef FU2_DETAIL_UNREACHABLE_INTRINSIC
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define FU2_DETAIL_UNREACHABLE_INTRINSIC() abort()
 #endif
@@ -89,10 +92,13 @@
 #elif defined(__GNUC__)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define FU2_DETAIL_TRAP() __builtin_trap()
-#elif defined(__has_builtin) && __has_builtin(__builtin_trap)
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_trap)
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define FU2_DETAIL_TRAP() __builtin_trap()
-#else
+#endif
+#endif
+#ifndef FU2_DETAIL_TRAP
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define FU2_DETAIL_TRAP() *(volatile int*)0x11 = 0
 #endif


### PR DESCRIPTION
@Naios <!-- This is required so I get notified properly -->

<!-- Please replace {Please write here} with your description -->

-----

### What was a problem?

A compile error will occur if "__has_builtin" is not defined.

### How this PR fixes the problem?

Fixed macro check for "__has_builtin".
