### PR TITLE
Use is_copy_constructible_v

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -1422,7 +1422,7 @@ struct use_bool_op<Ret(Args...) noexcept> : std::false_type {};
 template <typename Config, typename T>
 struct assert_wrong_copy_assign {
   static_assert(!Config::is_owning || !Config::is_copyable ||
-                    std::is_copy_constructible<std::decay_t<T>>::value,
+                    std::is_copy_constructible_v<std::decay_t<T>>,
                 "Can't wrap a non copyable object into a unique function!");
 
   using type = void;


### PR DESCRIPTION
gcc can not handle variant<cti::work, ...>. Using is_copy_constructible_v instead of is_copy_constructible<...>::value works around this problem.

@Naios

This solves issue https://github.com/Naios/continuable/issues/37

-----

### What was a problem?

Using std::variant<cti::work, ...> is not possible, because of a bug in gcc. 

### How this PR fixes the problem?

This fix uses is_copy_constructible_v instead of is_copy_constructible<>::value on line 1425.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [ ] Coding style (Clang format was applied)

### Additional Comments (if any)

