### PR TITLE
Allow configuring for AppleClang

### DIFF
--- a/cmake/configure_compiler.cmake
+++ b/cmake/configure_compiler.cmake
@@ -1,11 +1,11 @@
 # Select the compiler specific cmake file
 set(MSVC_ID "MSVC")
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+if (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
   include(${CMAKE_SOURCE_DIR}/cmake/compiler/clang.cmake)
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   include(${CMAKE_SOURCE_DIR}/cmake/compiler/gcc.cmake)
 elseif (${CMAKE_CXX_COMPILER_ID} STREQUAL ${MSVC_ID})
   include(${CMAKE_SOURCE_DIR}/cmake/compiler/msvc.cmake)
 else()
-  message(FATAL_ERROR "Unknown compiler!")
+  message(FATAL_ERROR "Unknown compiler: ${CMAKE_CXX_COMPILER_ID}")
 endif()


### PR DESCRIPTION
@Naios <!-- This is required so I get notified properly -->

Running CMake on function2 causes a failure if you select the generator -G Xcode while on an apple mac. This is because the CMAKE_COMPILER_ID for Apple's compiler is AppleClang. 

-----

### What was a problem?

Failure to configure when using Apple Clang.

### How this PR fixes the problem?

Modify the check for Clang to use a regex match on "Clang" so that it captures both AppleClang and Clang

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [ ] Coding style (Clang format was applied)

### Additional Comments (if any)

No tests required - the test is the fact that the project now configures correctly on a mac and continues to configure correctly on other Clang environments.