### PR TITLE
Prevent ADL when calling invoke

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -280,8 +280,9 @@ struct is_noexcept_correct : std::true_type {};
 template <typename T, typename... Args>
 struct is_noexcept_correct<true, T, identity<Args...>>
     : std::integral_constant<bool,
-                             noexcept((invoke)(std::declval<T>(),
-                                               std::declval<Args>()...))> {};
+                             noexcept(::fu2::detail::invocation::invoke(
+                                 std::declval<T>(), std::declval<Args>()...))> {
+};
 } // end namespace invocation
 
 namespace overloading {

--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -279,7 +279,7 @@ template <bool RequiresNoexcept, typename T, typename Args>
 struct is_noexcept_correct : std::true_type {};
 template <typename T, typename... Args>
 struct is_noexcept_correct<true, T, identity<Args...>>
-    : std::integral_constant<bool, noexcept(invoke(std::declval<T>(),
+    : std::integral_constant<bool, noexcept((invoke)(std::declval<T>(),
                                                    std::declval<Args>()...))> {
 };
 } // end namespace invocation

--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -279,9 +279,9 @@ template <bool RequiresNoexcept, typename T, typename Args>
 struct is_noexcept_correct : std::true_type {};
 template <typename T, typename... Args>
 struct is_noexcept_correct<true, T, identity<Args...>>
-    : std::integral_constant<bool, noexcept((invoke)(std::declval<T>(),
-                                                   std::declval<Args>()...))> {
-};
+    : std::integral_constant<bool,
+                             noexcept((invoke)(std::declval<T>(),
+                                               std::declval<Args>()...))> {};
 } // end namespace invocation
 
 namespace overloading {


### PR DESCRIPTION
@Naios <!-- This is required so I get notified properly -->

<!-- Please replace {Please write here} with your description -->

-----

### What was a problem?

When using function2 with **C++17**, there can be a problem if `functional` is included, too. Because of ADL the call to `invoke` in the namespace `fu2::abi_400::detail::invocation` becomes ambiguous if some parameter refer to something in the `std` namespace. Consider the following example:

```c++
#include <string>
#include <functional>
#include "function2/function2.hpp"

int main(int, char**) {
  fu2::unique_function<void(std::string) noexcept> cb;
  cb.assign([](std::string) noexcept {});
}
```
This will not compile using clang-11.0.0 or gcc 10.2.0. For example here the gcc output:
```
/home/****/function2/include/function2/function2.hpp:283:45: error: call of overloaded invoke(main(int, char**)::<lambda(std::string)>&, std::__cxx11::basic_string<char>) is ambiguous
  283 |                              noexcept(invoke(std::declval<T>(),
      |                                       ~~~~~~^~~~~~~~~~~~~~~~~~~
  284 |                                                std::declval<Args>()...))> {};
      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~
/home/****/function2/include/function2/function2.hpp:200:16: note: candidate: constexpr decltype (forward<Callable>(callable)((forward<Args>)(fu2::abi_400::detail::invocation::invoke::args)...)) fu2::abi_400::detail::invocation::invoke(Callable&&, Args&& ...) [with Callable = main(int, char**)::<lambda(std::string)>&; Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; decltype (forward<Callable>(callable)((forward<Args>)(fu2::abi_400::detail::invocation::invoke::args)...)) = void]
  200 | constexpr auto invoke(Callable&& callable, Args&&... args) noexcept(
      |                ^~~~~~
In file included from /home/****/function2/test/playground.cpp:8:
/usr/include/c++/10.2.0/functional:85:5: note: candidate: std::invoke_result_t<_Callable, _Args ...> std::invoke(_Callable&&, _Args&& ...) [with _Callable = main(int, char**)::<lambda(std::string)>&; _Args = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}; std::invoke_result_t<_Callable, _Args ...> = void]
   85 |     invoke(_Callable&& __fn, _Args&&... __args)
      |     ^~~~~~
```
### How this PR fixes the problem?

The fix prevents ADL resolution of `invoke` by preventing the left hand side of the call being an identifier.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [x] Coding style (Clang format was applied)

### Additional Comments (if any)

I did not an regression test. You can just use the example above.
