### PR TITLE
Add option to limit empty callable propagation to known types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,9 @@ if (FU2_IS_TOP_LEVEL_PROJECT)
   option(FU2_WITH_CPP_LATEST
       "Enable the highest C++ standard available for testing polyfills"
       OFF)
+  option(FU2_WITH_LIMITED_EMPTY_PROPAGATION
+      "Test limiting empty propagation to only function pointers, member pointers, std::function, and specializations of fu2::function_base"
+      OFF)
 
   if (BUILD_TESTING)
     if (FU2_WITH_NO_EXCEPTIONS)
@@ -123,6 +126,11 @@ if (FU2_IS_TOP_LEVEL_PROJECT)
     if (FU2_WITH_NO_DEATH_TESTS)
       message(STATUS "Testing without death tests")
       add_definitions(-DTESTS_NO_DEATH_TESTS)
+    endif()
+
+    if (FU2_WITH_LIMITED_EMPTY_PROPAGATION)
+      message(STATUS "Testing with limited empty propagation")
+      add_definitions(-DFU2_WITH_LIMITED_EMPTY_PROPAGATION)
     endif()
 
     add_subdirectory(test)

--- a/test/empty-function-call-test.cpp
+++ b/test/empty-function-call-test.cpp
@@ -96,7 +96,12 @@ TYPED_TEST(AllEmptyFunctionCallTests, CallPropagatesEmptyCustom) {
   {
     typename TestFixture::template left_t<void(some_tag)> fn(
         my_callable_empty{});
+#if defined(FU2_HAS_LIMITED_EMPTY_PROPAGATION) ||                              \
+    defined(FU2_HAS_NO_EMPTY_PROPAGATION)
+    ASSERT_FALSE(fn.empty());
+#else
     ASSERT_TRUE(fn.empty());
+#endif
   }
 }
 #endif // FU2_HAS_NO_EMPTY_PROPAGATION

--- a/test/regressions.cpp
+++ b/test/regressions.cpp
@@ -127,11 +127,11 @@ TEST(regression_tests, can_assign_nonowning_noncopyable_view) {
 
 static fu2::unique_function<void()> issue_14_create() {
   // remove the commented dummy capture to be compilable
-  fu2::unique_function<void()>
-      func = [i = std::vector<std::vector<std::unique_ptr<int>>>{}
-              // ,dummy = std::unique_ptr<int>()
-  ](){
-          // ...
+  fu2::unique_function<void()> func =
+      [i = std::vector<std::vector<std::unique_ptr<int>>>{}
+       // ,dummy = std::unique_ptr<int>()
+  ]() {
+        // ...
       };
 
   return std::move(func);
@@ -198,6 +198,35 @@ TEST(regression_tests, unique_non_copyable) {
 
   ASSERT_EQ(view(), 5);
 }*/
+
+// https://github.com/Naios/function2/issues/48
+// -Waddress warning generated for non-capturing lambdas on gcc <= 9.2 #48
+TEST(regression_tests, no_address_warning_in_constexpr_lambda) {
+  using fun_t = fu2::function<int()>;
+  fun_t f([] { return 3836474; });
+
+  ASSERT_EQ(f(), 3836474);
+}
+
+struct custom_falsy_invocable {
+  operator bool() const {
+    return false;
+  }
+  int operator()() const {
+    return 0;
+  }
+};
+
+TEST(regression_tests, custom_falsy_invocable) {
+  fu2::function<int()> f(custom_falsy_invocable{});
+
+#if defined(FU2_HAS_LIMITED_EMPTY_PROPAGATION) ||                              \
+    defined(FU2_HAS_NO_EMPTY_PROPAGATION)
+  ASSERT_TRUE(static_cast<bool>(f));
+#else
+  ASSERT_FALSE(static_cast<bool>(f));
+#endif
+}
 
 namespace issue_35 {
 class ref_obj {


### PR DESCRIPTION
This approach roughly matches the one used by std::function, explicitly
enumerating the types which are supported for empty propagation.

Fixes #48
