### PR TITLE
chore: silence Visual Studio 2022 (17.3.0) warning

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -1173,7 +1173,7 @@ public:
   FU2_DETAIL_CXX14_CONSTEXPR erasure(std::true_type /*use_bool_op*/,
                                      T&& callable,
                                      Allocator&& allocator_ = Allocator{}) {
-    if (bool(callable)) {
+    if (!!callable) {
       vtable_t::init(vtable_,
                      type_erasure::make_box(
                          std::integral_constant<bool, Config::is_copyable>{},


### PR DESCRIPTION
Starting with Visual Studio 2022 (17.3.0) the following warning is emitted:

```
include\function2\function2.hpp(1176): warning C4305: '<function-style-cast>': truncation from 'bool (__cdecl *)(void)' to 'bool'
```

Neither `bool(callable)` (as it was written), nor `static_cast<bool>(callable)` seem to make the compiler happy. It worked with either `!!` or omitting it completely.

@Naios
