### PR TITLE
Fix issue #21

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -339,7 +339,8 @@ template <typename T, typename = void>
 struct address_taker {
   template <typename O>
   static void* take(O&& obj) {
-    return std::addressof(obj);
+    const void *ret = std::addressof(obj);
+    return const_cast<void*>(ret);
   }
   static T& restore(void* ptr) {
     return *static_cast<T*>(ptr);

--- a/test/regressions.cpp
+++ b/test/regressions.cpp
@@ -191,13 +191,13 @@ TEST(regression_tests, unique_non_copyable) {
 }
 
 // https://github.com/Naios/function2/issues/21
-/*TEST(regression_tests, can_bind_const_view) {
+TEST(regression_tests, can_bind_const_view) {
   auto const callable = [] { return 5; };
 
   fu2::function_view<int() const> view(callable);
 
   ASSERT_EQ(view(), 5);
-}*/
+}
 
 // https://github.com/Naios/function2/issues/48
 // -Waddress warning generated for non-capturing lambdas on gcc <= 9.2 #48


### PR DESCRIPTION
This makes it possible to use const functions in function_views by fixing constness when setting the data pointer to the function.