### PR TITLE
Fix warning for MSVC

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -1245,7 +1245,7 @@ public:
   template <typename T, typename Allocator = std::allocator<std::decay_t<T>>>
   void assign(std::true_type /*use_bool_op*/, T&& callable,
               Allocator&& allocator_ = {}) {
-    if (bool(callable)) {
+    if (!!callable) {
       assign(std::false_type{}, std::forward<T>(callable),
              std::forward<Allocator>(allocator_));
     } else {
@@ -1366,7 +1366,7 @@ public:
   }
   template <typename T>
   constexpr void assign(std::true_type /*use_bool_op*/, T&& callable) {
-    if (bool(callable)) {
+    if (!!callable) {
       assign(std::false_type{}, std::forward<T>(callable));
     } else {
       operator=(nullptr);


### PR DESCRIPTION
@Naios 

Same issue already was fixed but in different function
https://github.com/Naios/function2/commit/2d3a878ef19dd5d2fb188898513610fac0a48621

```
C:\project\3rdParty\iresearch\external\function2/function2.hpp(1358,1): error C2220: the following warning is treated as an error (compiling source file C:\project\arangod\Aql\IResearchViewNode.cpp) [C:\project\build\arangod\Aql\arango_aql.vcxproj]
C:\project\3rdParty\iresearch\external\function2/function2.hpp(1319): message : see reference to function template instantiation 'void fu2::abi_400::detail::type_erasure::erasure<false,Config,fu2::abi_400::detail::property<true,false,bool (const arangodb::aql::Variable *)>>::assign<_Ty>(std::true_type,T &&)' being compiled [C:\project\build\arangod\Aql\arango_aql.vcxproj]
          with
          [
              Config=fu2::abi_400::detail::config<false,true,fu2::capacity_default>,
              _Ty=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>,
              T=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>
          ] (compiling source file C:\project\arangod\Aql\IResearchViewNode.cpp)
C:\project\3rdParty\iresearch\external\function2/function2.hpp(1320): message : see reference to function template instantiation 'void fu2::abi_400::detail::type_erasure::erasure<false,Config,fu2::abi_400::detail::property<true,false,bool (const arangodb::aql::Variable *)>>::assign<_Ty>(std::true_type,T &&)' being compiled [C:\project\build\arangod\Aql\arango_aql.vcxproj]
          with
          [
              Config=fu2::abi_400::detail::config<false,true,fu2::capacity_default>,
              _Ty=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>,
              T=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>
          ] (compiling source file C:\project\arangod\Aql\IResearchViewNode.cpp)
C:\project\3rdParty\iresearch\external\function2/function2.hpp(1581): message : see reference to function template instantiation 'fu2::abi_400::detail::type_erasure::erasure<false,Config,fu2::abi_400::detail::property<true,false,bool (const arangodb::aql::Variable *)>>::erasure<_Ty>(std::true_type,T &&)' being compiled [C:\project\build\arangod\Aql\arango_aql.vcxproj]
          with
          [
              Config=fu2::abi_400::detail::config<false,true,fu2::capacity_default>,
              _Ty=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>,
              T=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>
          ] (compiling source file C:\project\arangod\Aql\IResearchViewNode.cpp)
C:\project\3rdParty\iresearch\external\function2/function2.hpp(1581): message : see reference to function template instantiation 'fu2::abi_400::detail::type_erasure::erasure<false,Config,fu2::abi_400::detail::property<true,false,bool (const arangodb::aql::Variable *)>>::erasure<_Ty>(std::true_type,T &&)' being compiled [C:\project\build\arangod\Aql\arango_aql.vcxproj]
          with
          [
              Config=fu2::abi_400::detail::config<false,true,fu2::capacity_default>,
              _Ty=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>,
              T=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>
          ] (compiling source file C:\project\arangod\Aql\IResearchViewNode.cpp)
C:\project\arangod\Aql\IResearchViewNode.cpp(517): message : see reference to function template instantiation 'fu2::abi_400::detail::function<fu2::abi_400::detail::config<false,true,fu2::capacity_default>,fu2::abi_400::detail::property<true,false,bool (const arangodb::aql::Variable *)>>::function<arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>,0x0,0x0,0x0,0x0>(T &&)' being compiled [C:\project\build\arangod\Aql\arango_aql.vcxproj]
          with
          [
              T=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>
          ]
C:\project\arangod\Aql\IResearchViewNode.cpp(516): message : see reference to function template instantiation 'fu2::abi_400::detail::function<fu2::abi_400::detail::config<false,true,fu2::capacity_default>,fu2::abi_400::detail::property<true,false,bool (const arangodb::aql::Variable *)>>::function<arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>,0x0,0x0,0x0,0x0>(T &&)' being compiled [C:\project\build\arangod\Aql\arango_aql.vcxproj]
          with
          [
              T=arangodb::iresearch::`anonymous-namespace'::evaluateVolatility::<lambda_1>
          ]
C:\project\3rdParty\iresearch\external\function2/function2.hpp(1358,1): warning C4305: '<function-style-cast>': truncation from 'bool (__cdecl *)(const arangodb::aql::Variable *)' to 'bool' (compiling source file C:\project\arangod\Aql\IResearchViewNode.cpp) [C:\project\build\arangod\Aql\arango_aql.vcxproj]
```