### PR TITLE
fix: disable `use_bool_op` in objective c (#32)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.11)
-project(function2 VERSION 4.2.0 LANGUAGES CXX)
+project(function2 VERSION 4.2.3 LANGUAGES CXX)
 
 if (NOT FU2_IS_FIND_INCLUDED)
   string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}
@@ -36,6 +36,8 @@ target_compile_features(function2
     cxx_trailing_return_types
     cxx_return_type_deduction)
 
+install(DIRECTORY "include/function2" TYPE INCLUDE)
+
 if (FU2_IS_TOP_LEVEL_PROJECT)
   include(ExternalProject)
   include(GNUInstallDirs)
@@ -43,8 +45,6 @@ if (FU2_IS_TOP_LEVEL_PROJECT)
 
   # Create an install target:
   # Headers and license files
-  install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/function2"
-          DESTINATION "include")
   install(FILES "LICENSE.txt" DESTINATION .)
   install(FILES "Readme.md" DESTINATION .)
 

--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -1408,7 +1408,12 @@ struct accepts_all<
     void_t<std::enable_if_t<accepts_one<T, Signatures>::value>...>>
     : std::true_type {};
 
-#if defined(FU2_HAS_NO_EMPTY_PROPAGATION)
+#if defined(__OBJC__)
+/// In Objective C lambdas can be implicitly converted to block pointers,
+/// thus causing the copy constructor to be invoked.
+template <typename T>
+struct use_bool_op : std::false_type {};
+#elif defined(FU2_HAS_NO_EMPTY_PROPAGATION)
 template <typename T>
 struct use_bool_op : std::false_type {};
 #elif defined(FU2_HAS_LIMITED_EMPTY_PROPAGATION)


### PR DESCRIPTION
@Naios <!-- This is required so I get notified properly -->

<!-- Please replace {Please write here} with your description -->

-----

### What was a problem?

See #32

### How this PR fixes the problem?

This PR disables `use_bool_op` when Objective C is detected.  

I would appreciate some help to to update this PR to a more robust implementation though.
I've written a small POC that adds an additional check to `has_bool_op` that fails when the given type is convertible to a block-pointer: https://godbolt.org/z/GhM63xYnd

The implementation seen above is not implemented in this PR as I've used std::function to deduce the return and parameter types. I tried to do this with the `function_trait` found in the library, however, it does not seem to cover lambdas ootb, so I figured I might ask here first before modifying `function_trait`.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [x] Coding style (Clang format was applied)
