### PR TITLE
stop using std::aligned_storage_t

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -1084,7 +1084,9 @@ struct internal_capacity {
     /// Tag to access the structure in a type-safe way
     data_accessor accessor_;
     /// The internal capacity we use to allocate in-place
-    std::aligned_storage_t<Capacity::capacity, Capacity::alignment> capacity_;
+    struct alignas(Capacity::alignment) {
+      unsigned char data[Capacity::capacity];
+    } capacity_;
   } type;
 };
 template <typename Capacity>


### PR DESCRIPTION
previously, we were using std::aligned_storage_t, which was deprecated in C++23, so let's use the equivalent alignas specifier and use an anonymous struct for reserving the internal capacity.

Fixes #66

@Naios <!-- This is required so I get notified properly -->

<!-- Please replace {Please write here} with your description -->

-----

### What was a problem?

{Please write here}

### How this PR fixes the problem?

{Please write here}

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [x] Coding style (Clang format was applied)

### Additional Comments (if any)

{Please write here}
