### PR TITLE
appveyor: do not override clone_script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,10 +16,7 @@ environment:
 platform:
   - x64
 
-clone_script:
-  - cmd: git clone -q --branch=%APPVEYOR_REPO_BRANCH% https://github.com/%APPVEYOR_REPO_NAME%.git %APPVEYOR_BUILD_FOLDER%
-  - cmd: cd %APPVEYOR_BUILD_FOLDER%
-  - cmd: git checkout -qf %APPVEYOR_REPO_COMMIT%
+install:
   - cmd: git submodule update --init --recursive
 
 before_build:


### PR DESCRIPTION
previously, we overrided the repo cloning method by specifying the "clone_script" section. but when the "git clone" command failed to fetch the merge commit of a pull request under test.

in this change, instead of overriding the clone method, we just reuse the default cloning method, and specify the install section to prepare the submodules.

@Naios <!-- This is required so I get notified properly -->

<!-- Please replace {Please write here} with your description -->

-----

### What was a problem?

{Please write here}

### How this PR fixes the problem?

{Please write here}

### Check lists (check `x` in `[ ]` of list items)

- [ ] Additional Unit Tests were added that test the feature or regression
- [ ] Coding style (Clang format was applied)

### Additional Comments (if any)

{Please write here}
