### PR TITLE
Avoid extra move in box construction

### DIFF
--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -397,7 +397,7 @@ struct box<false, T, Allocator> : private Allocator {
   T value_;
 
   explicit box(const T& value, Allocator allocator_)
-      : Allocator(std::move(allocator_)), value_(std::move(value)) {
+      : Allocator(std::move(allocator_)), value_(value) {
   }
 
   explicit box(T&& value, Allocator allocator_)

--- a/include/function2/function2.hpp
+++ b/include/function2/function2.hpp
@@ -376,7 +376,11 @@ struct box : private Allocator {
 
   T value_;
 
-  explicit box(T value, Allocator allocator_)
+  explicit box(const T& value, Allocator allocator_)
+      : Allocator(std::move(allocator_)), value_(value) {
+  }
+
+  explicit box(T&& value, Allocator allocator_)
       : Allocator(std::move(allocator_)), value_(std::move(value)) {
   }
 
@@ -392,7 +396,11 @@ struct box<false, T, Allocator> : private Allocator {
 
   T value_;
 
-  explicit box(T value, Allocator allocator_)
+  explicit box(const T& value, Allocator allocator_)
+      : Allocator(std::move(allocator_)), value_(std::move(value)) {
+  }
+
+  explicit box(T&& value, Allocator allocator_)
       : Allocator(std::move(allocator_)), value_(std::move(value)) {
   }
 

--- a/test/regressions.cpp
+++ b/test/regressions.cpp
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "function2-test.hpp"
@@ -260,4 +261,44 @@ TYPED_TEST(AllReferenceRetConstructTests, reference_returns_not_buildable) {
   typename TestFixture::template left_t<ref_obj&()> left(&ref_obj_getter);
   ref_obj& ref = left();
   ASSERT_EQ(ref.data(), 8373827);
+}
+
+/// Functor which counts the number of times it has been copied or moved
+class CopyAndMoveCountFunctor {
+  int copy_count = 0;
+  int move_count = 0;
+
+public:
+  CopyAndMoveCountFunctor() = default;
+
+  CopyAndMoveCountFunctor(const CopyAndMoveCountFunctor& that) {
+    *this = that;
+  }
+
+  CopyAndMoveCountFunctor& operator=(const CopyAndMoveCountFunctor& that) {
+    copy_count = that.copy_count + 1;
+    move_count = that.move_count;
+    return *this;
+  }
+
+  CopyAndMoveCountFunctor(CopyAndMoveCountFunctor&& that) {
+    *this = std::move(that);
+  }
+
+  CopyAndMoveCountFunctor& operator=(CopyAndMoveCountFunctor&& that) {
+    copy_count = that.copy_count;
+    move_count = that.move_count + 1;
+    return *this;
+  }
+
+  ~CopyAndMoveCountFunctor() = default;
+
+  std::pair<int, int> operator()() const {
+    return std::make_pair(copy_count, move_count);
+  }
+};
+
+TEST(regression_tests, no_extra_move_during_construction) {
+  fu2::function<std::pair<int, int>()> f(CopyAndMoveCountFunctor{});
+  ASSERT_EQ(f(), std::make_pair(0, 2));
 }


### PR DESCRIPTION
@Naios <!-- This is required so I get notified properly -->

Hi, I noticed constructing function involves at least three moves of my callable. In my use-case an extra move costs 150ns+.
One of the extra moves is easy to avoid by forwarding a reference to constructor of box. The other extra move caused by that box being temporary before a move into vtable_t is harder to remove. I'm not addressing it in this PR.

-----

### What was a problem?

Since box::box accepts T by value, make_box contructs a temporary T when passing callable to constructor of box.

### How this PR fixes the problem?

I replace `box::box(T, Allocator)` with two overloads: `box::box(const T&, Allocator)` and `box::box(T&&, Allocator)`.
This way user-provided lvalue- or rvalue-reference gets forwarded all the way to construction of `box::value_`.

### Check lists (check `x` in `[ ]` of list items)

- [x] Additional Unit Tests were added that test the feature or regression
- [x] Coding style (Clang format was applied)

### Additional Comments (if any)